### PR TITLE
Ts error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/src/components/settings-screen.tsx
+++ b/src/components/settings-screen.tsx
@@ -222,7 +222,7 @@ export default function SettingsScreen(props: SettingsScreenProps) {
                                     <audio controls style={{ display: 'none' }} id="voice-preview" key={context.voice.id}>
                                         <source src={voices.find(v => v.voice_id === context.voice.id)?.preview_url} type="audio/mpeg" />
                                     </audio>
-                                    <Button onClick={() => document.getElementById('voice-preview')?.play()} variant='light' compact style={{ marginTop: '1rem' }}>
+                                    <Button onClick={() => (document.getElementById('voice-preview') as HTMLMediaElement)?.play()} variant='light' compact style={{ marginTop: '1rem' }}>
                                         <i className='fa fa-headphones' />
                                         <span>Preview voice</span>
                                     </Button>


### PR DESCRIPTION
The error message "TS2339: Property 'play' does not exist on type 'HTMLElement'" indicates that TypeScript is unable to find the play property on the HTMLElement type.

To fix this error, you can explicitly cast the document.getElementById('voice-preview') expression to the HTMLMediaElement type, which includes the play method. 

`<Button onClick={() => (document.getElementById('voice-preview') as HTMLMediaElement)?.play()} variant='light' compact style={{ marginTop: '1rem' }}>`
