### PR TITLE
fix redundancy in chatManager class

### DIFF
--- a/app/src/chat-manager.ts
+++ b/app/src/chat-manager.ts
@@ -93,7 +93,9 @@ export class ChatManager extends EventEmitter {
         const messages: Message[] = message.parentID
             ? chat.messages.getMessageChainTo(message.parentID)
             : [];
-        messages.push(newMessage);
+        if (messages.length === 0) {
+            messages.push(newMessage);
+        }
 
         await this.getReply(messages, message.requestedParameters);
     }


### PR DESCRIPTION
The `getMessageChainTo() ` method in the MessageTree class currently returns an array that already includes the message itself, so no need to push it again into the messages array.