### PR TITLE
introduce env variable DISABLE_RATE_LIMIT to disable rate limit

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -67,13 +67,15 @@ export default class ChatServer {
         this.app.use(express.json({ limit: '1mb' }));
         this.app.use(compression());
 
-        const { default: rateLimit } = await import('express-rate-limit'); // esm
-        const limiter = rateLimit({
-            windowMs: 15 * 60 * 1000, // 15 minutes
-            max: 100, // limit each IP to 100 requests per windowMs
-        });
+        if (process.env.DISABLE_RATE_LIMIT !== 'true') {
+            const { default: rateLimit } = await import('express-rate-limit'); // esm
+            const limiter = rateLimit({
+                windowMs: 15 * 60 * 1000, // 15 minutes
+                max: 100, // limit each IP to 100 requests per windowMs
+            });
 
-        this.app.use(limiter);
+            this.app.use(limiter);
+        }
 
         this.app.get('/chatapi/health', (req, res) => new HealthRequestHandler(this, req, res));
         this.app.get('/chatapi/session', (req, res) => new SessionRequestHandler(this, req, res));

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -67,15 +67,16 @@ export default class ChatServer {
         this.app.use(express.json({ limit: '1mb' }));
         this.app.use(compression());
 
-        if (process.env.DISABLE_RATE_LIMIT !== 'true') {
-            const { default: rateLimit } = await import('express-rate-limit'); // esm
-            const limiter = rateLimit({
-                windowMs: 15 * 60 * 1000, // 15 minutes
-                max: 100, // limit each IP to 100 requests per windowMs
-            });
+        
+        const rateLimitWindowMs = process.env.RATE_LIMIT_WINDOW_MS ? parseInt(process.env.RATE_LIMIT_WINDOW_MS, 10) : 15 * 60 * 1000; // 15 minutes
+        const rateLimitMax = process.env.RATE_LIMIT_MAX ? parseInt(process.env.RATE_LIMIT_MAX, 10) : 100; // limit each IP to 100 requests per windowMs
 
-            this.app.use(limiter);
-        }
+        const { default: rateLimit } = await import('express-rate-limit'); // esm
+        const limiter = rateLimit({
+            windowMs: rateLimitWindowMs,
+            max: rateLimitMax,
+        });
+        this.app.use(limiter);
 
         this.app.get('/chatapi/health', (req, res) => new HealthRequestHandler(this, req, res));
         this.app.get('/chatapi/session', (req, res) => new SessionRequestHandler(this, req, res));


### PR DESCRIPTION
We locally run into rate limiting. since we don't want to specify a rate limiting within the company at all, especially because some NAT clients use the same IP, we introduced this variable with minimal changes.