### PR TITLE
Fix non-serializable error message

### DIFF
--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -1,11 +1,20 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import {
+  FLUSH,
+  PAUSE,
+  PERSIST,
+  PURGE,
+  REGISTER,
+  REHYDRATE,
+  persistReducer,
+  persistStore,
+} from "redux-persist";
 import storage from 'redux-persist/lib/storage';
-import { persistReducer, persistStore } from 'redux-persist';
 import messageReducer from './message';
-import uiReducer from './ui';
 import settingsUIReducer from './settings-ui';
 import sidebarReducer from './sidebar';
+import uiReducer from './ui';
 
 const persistConfig = {
   key: 'root',
@@ -26,12 +35,18 @@ const persistMessageConfig = {
 
 const store = configureStore({
   reducer: {
-    message: persistReducer(persistMessageConfig, messageReducer),
+    message: persistReducer<ReturnType<typeof messageReducer>>(persistMessageConfig, messageReducer),
     ui: uiReducer,
     settingsUI: settingsUIReducer,
-    sidebar: persistReducer(persistSidebarConfig, sidebarReducer),
+    sidebar: persistReducer<ReturnType<typeof sidebarReducer>>(persistSidebarConfig, sidebarReducer),
   },
-})
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: {
+        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+      },
+    }),
+});
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
Using Redux Toolkit together with redux-persist requires some additional configuration to disable the non-serializable error message: https://redux-toolkit.js.org/usage/usage-guide#use-with-redux-persist