### PR TITLE
make <ol> in markdown start at 1 instead of 2

### DIFF
--- a/app/src/components/markdown.tsx
+++ b/app/src/components/markdown.tsx
@@ -84,7 +84,7 @@ export function Markdown(props: MarkdownProps) {
                 rehypePlugins={rehypePlugins}
                 components={{
                     ol({ start, children }) {
-                        return <ol start={start ?? 1} style={{ counterReset: `list-item ${(start || 1)}` }}>
+                        return <ol start={start ?? 0} style={{ counterReset: `list-item ${(start || 0)}` }}>
                             {children}
                         </ol>;
                     },


### PR DESCRIPTION
ols by default start with 2. Adjusting the default start value in the markdown component remedies this problem.