### PR TITLE
Customise login expiry

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -81,6 +81,15 @@ export interface Config {
         windowMs?: number;
         max?: number;
     };
+
+    /*
+    The amount of time before the session expires and a user must log in again.
+    */
+    sessionTimeout?: {
+        days: number,
+        hours: number,
+        minutes: number
+    }
 }
 
 // default config:

--- a/server/src/passport.ts
+++ b/server/src/passport.ts
@@ -8,6 +8,7 @@ import ChatServer from './index';
 import { config } from './config';
 
 const secret = config.authSecret;
+const sessionTimeout = config.sessionTimeout;
 
 export function configurePassport(context: ChatServer) {
     const SQLiteStore = createSQLiteSessionStore(session);
@@ -51,6 +52,13 @@ export function configurePassport(context: ChatServer) {
         secret,
         resave: false,
         saveUninitialized: false,
+        cookie: {
+            maxAge: sessionTimeout
+                ? (sessionTimeout.days * (1000 * 60 * 60 * 24))
+                + (sessionTimeout.hours * (1000 * 60 * 60))
+                + (sessionTimeout.minutes * (1000 * 60))
+                : undefined
+        },
         store: sessionStore as any,
     }));
     context.app.use(passport.authenticate('session'));


### PR DESCRIPTION
I wanted my login to last longer. With this change the config.yml can be modified to set the amount of days, hours, minutes you might want the cookie to be valid for. If the config file isn't set then it uses the default of however long the session lasts.

```yaml
sessionTimeout:
  days: 365
  hours: 0
  minutes: 0
```
I noticed an issue exists for it here #138 
