### PR TITLE
If the request is proxified, do not add empty "Authorization" header.

### DIFF
--- a/app/src/core/chat/openai.ts
+++ b/app/src/core/chat/openai.ts
@@ -62,8 +62,8 @@ export async function createChatCompletion(messages: OpenAIMessage[], parameters
         method: "POST",
         headers: {
             'Accept': 'application/json, text/plain, */*',
-            'Authorization': !proxied ? `Bearer ${parameters.apiKey}` : '',
             'Content-Type': 'application/json',
+			... !proxied ? {'Authorization': `Bearer ${parameters.apiKey}`} : {},
         },
         body: JSON.stringify({
             "model": parameters.model,
@@ -91,8 +91,8 @@ export async function createStreamingChatCompletion(messages: OpenAIMessage[], p
         method: "POST",
         headers: {
             'Accept': 'application/json, text/plain, */*',
-            'Authorization': !proxied ? `Bearer ${parameters.apiKey}` : '',
             'Content-Type': 'application/json',
+			... !proxied ? {'Authorization': `Bearer ${parameters.apiKey}`} : {},
         },
         payload: JSON.stringify({
             "model": parameters.model,


### PR DESCRIPTION
If the whole app is behind http auth, browser adds auth header to all requests, but adding it empty overrides header added by browser.

So, I just basically tried hosting my own instance behind basic HTTP auth (added through reverse proxy) and had to fix this for it to work.