### PR TITLE
Update available models, change system prompt

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -23,7 +23,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
-    "react-intl": "^6.2.10",
+    "react-intl": "^6.5.5",
     "react-markdown": "^8.0.5",
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.8.2",
@@ -68,7 +68,7 @@
     "@types/uuid": "^9.0.1",
     "@vitejs/plugin-react": "^4.0.2",
     "babel-plugin-formatjs": "^10.5.3",
-    "typescript": "^4.9.5",
+    "typescript": "^5.3.2",
     "vite": "^4.4.1",
     "vite-plugin-pwa": "^0.16.4",
     "workbox-window": "^7.0.0"

--- a/app/src/global-options/parameters.tsx
+++ b/app/src/global-options/parameters.tsx
@@ -29,39 +29,25 @@ export const parameterOptions: OptionGroup = {
                 ),
                 options: [
                     {
-                        label: "GPT 3.5 Turbo (default)",
-                        value: "gpt-3.5-turbo",
+                        label: "GPT-4 Turbo (128k context)",
+                        value: "gpt-4-1106-preview",
                     },
                     {
-                        label: "GPT 3.5 Turbo 16k",
-                        value: "gpt-3.5-turbo-16k",
-                    },
-                    {
-                        label: "GPT 4",
+                        label: "GPT-4",
                         value: "gpt-4",
                     },
                     {
-                        label: "GPT 4 32k (requires invite)",
+                        label: "GPT-4 (32k context)",
                         value: "gpt-4-32k",
                     },
                     {
-                        label: "GPT 4 Snapshot (June 13, 2023)",
-                        value: "gpt-4-0613",
-                    },
-          
-                    {
-                        label: "GPT 4 32k Snapshot (June 13, 2023)",
-                        value: "gpt-4-32k-0613",
-                    },
-  
-                    {
-                        label: "GPT 3.5 Turbo Snapshot (June 13, 2023)",
-                        value: "gpt-3.5-turbo-0613",
+                        label: "GPT-3.5 Turbo",
+                        value: "gpt-3.5-turbo",
                     },
                     {
-                        label: "GPT 3.5 Turbo 16k Snapshot (June 13, 2023)",
-                        value: "gpt-3.5-turbo-16k-0613",
-                    },
+                        label: "GPT 3.5 Turbo (16k context)",
+                        value: "gpt-3.5-turbo-16k",
+                    }
                 ],
             }),
         },

--- a/app/src/global-options/parameters.tsx
+++ b/app/src/global-options/parameters.tsx
@@ -30,7 +30,7 @@ export const parameterOptions: OptionGroup = {
                 options: [
                     {
                         label: "GPT-4 Turbo (128k context)",
-                        value: "gpt-4-1106-preview",
+                        value: "gpt-4-turbo-preview",
                     },
                     {
                         label: "GPT-4",

--- a/app/src/plugins/system-prompt.tsx
+++ b/app/src/plugins/system-prompt.tsx
@@ -5,8 +5,6 @@ import { OpenAIMessage, Parameters } from "../core/chat/types";
 
 export const defaultSystemPrompt = `
 You are ChatGPT, a large language model trained by OpenAI.
-Knowledge cutoff: 2021-09
-Current date and time: {{ datetime }}
 `.trim();
 
 export interface SystemPromptPluginOptions {


### PR DESCRIPTION
Hi there, big fan of this UI. I do miss the hosted variant chatwithgpt.ai, but I'm happy to settle for one I can run in docker.

I've taken the liberty of updating the model list to have the up-to-date models as of the dev day a few weeks ago as I really want an easy UI for using the new gpt-4-turbo (which is sick by the way with an April 2023 cut off!)

Feel free to merge this changes. 

## Changes
- Fixed some dependencies in `app/` to make it build (updated react-intl and typescript)
- Modified parameters.ts to include gpt-4-turbo and gpt-4-32k 
- Removed mentions of invites, etc as that's no longer the case

Cheers for the work you did on this! 